### PR TITLE
feat: add reusable ProviderCard component with navigation to detail page

### DIFF
--- a/src/components/ProviderCard.tsx
+++ b/src/components/ProviderCard.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import { useNavigate } from 'react-router-dom';
+import {type Provider } from '../types/provider.type';
+
+type Props = { provider: Provider };
+
+const ProviderCard: React.FC<Props> = ({ provider }) => {
+  const navigate = useNavigate();
+
+  return (
+    <div className="border rounded p-4 hover:bg-gray-100 cursor-pointer" onClick={() => navigate(`/providers/${provider.id}`)}>
+      <h2 className="text-lg font-semibold">{provider.name}</h2>
+      <p>{provider.specialization}</p>
+      <p>{provider.location}</p>
+      <p>⭐ {provider.rating}</p>
+    </div>
+  );
+};
+
+export default ProviderCard;


### PR DESCRIPTION
✅ Key Additions

- A reusable card component that:
- Displays key details about a provider (name, specialization, location, rating).
- Uses useNavigate from React Router to navigate to the provider's detail page on click.
- Accepts a Provider object as a prop and ensures type safety via TypeScript.

🎯 Purpose

- Promotes component reuse across the app (e.g., list views, search results).
- Streamlines navigation from provider list to detail view.
- Maintains consistency and type safety in UI rendering.

